### PR TITLE
bug/11735324 Fix temp folder visibility

### DIFF
--- a/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/CardShowTakenPictureView.java
+++ b/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/CardShowTakenPictureView.java
@@ -43,7 +43,7 @@ public class CardShowTakenPictureView extends LinearLayout implements CardShowTa
     public static final String KEY_IS_MULTIPLE_GALLERY_SELECTION = "is_multiple_gallery_selection";
     public static final int REQUEST_IMAGE_LIST_RESULT            = 2;
     public boolean canEditState;
-    private File mSdcardTempImagesDirectory = getPrivateTempDirectory();
+    private File mSdcardTempImagesDirectory = getPrivateTempDirectory(getContext());
     private File mPhotoTaken;
     private CardShowTakenPictureViewBinding mCardShowTakenPictureViewBinding;
     private CardShowTakenPicturePreviewDialogBinding mCardShowTakenPicturePreviewDialogBinding;
@@ -202,7 +202,7 @@ public class CardShowTakenPictureView extends LinearLayout implements CardShowTa
             for (CardShowTakenImage cardShowTakenImage :
                     imagesAsRemoved) {
                 if (cardShowTakenImage.getLocalImageFilename() != null) {
-                    File file = new File(getPrivateTempDirectory() + "/" + cardShowTakenImage.getLocalImageFilename());
+                    File file = new File(getPrivateTempDirectory(getContext()) + "/" + cardShowTakenImage.getLocalImageFilename());
                     if (file.exists()) {
                         file.delete();
                     }

--- a/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/camera/CameraFragment.java
+++ b/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/camera/CameraFragment.java
@@ -63,7 +63,7 @@ public class CameraFragment extends Fragment implements CameraContract {
 
     private CameraFragmentBinding mCameraFragmentBinding;
     private CameraPhotosAdapter mCameraPhotosAdapter;
-    private File mPath = ImageViewFileUtil.getPrivateTempDirectory();
+    private File mPath;
     private ImageButton mButtonCapture;
     private CameraSetup mCameraSetup;
     private ImageView mButtonReturnPhotos;
@@ -104,6 +104,8 @@ public class CameraFragment extends Fragment implements CameraContract {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        mPath = ImageViewFileUtil.getPrivateTempDirectory(getContext());
+
         getActivity().getWindow().setFlags(
                 WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED,
                 WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
@@ -112,7 +114,7 @@ public class CameraFragment extends Fragment implements CameraContract {
 
         mDialogLoader        = new DialogLoader(getContext());
         mImageGenerator      = new ImageGenerator(getContext());
-        mCameraPhotosAdapter = new CameraPhotosAdapter(this);
+        mCameraPhotosAdapter = new CameraPhotosAdapter(getContext(), this);
     }
 
     @Nullable

--- a/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/camera/CameraPhotosAdapter.java
+++ b/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/camera/CameraPhotosAdapter.java
@@ -1,6 +1,7 @@
 package br.com.stant.libraries.cardshowviewtakenpicturesview.camera;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.databinding.DataBindingUtil;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -23,10 +24,12 @@ public class CameraPhotosAdapter extends RecyclerView.Adapter<CameraPhotosAdapte
     private CameraFragment mCameraFragment;
     private ItemViewHolder mViewHolder;
     private List<CameraPhoto> mPhotos;
+    private final Context mContext;
 
-    public CameraPhotosAdapter(CameraFragment cameraFragment) {
+    public CameraPhotosAdapter(Context context, CameraFragment cameraFragment) {
         this.mCameraFragment = cameraFragment;
         this.mPhotos         = new ArrayList<>();
+        this.mContext        = context;
     }
 
     @Override
@@ -56,7 +59,7 @@ public class CameraPhotosAdapter extends RecyclerView.Adapter<CameraPhotosAdapte
     public void removePhoto(View view, CameraPhoto cameraPhoto){
         int position = mPhotos.indexOf(cameraPhoto);
         mPhotos.remove(cameraPhoto);
-        File file = new File(getPrivateTempDirectory().toString() + "/" + cameraPhoto.getLocalImageFilename());
+        File file = new File(getPrivateTempDirectory(mContext).toString() + "/" + cameraPhoto.getLocalImageFilename());
         if(file.delete()){
             mCameraFragment.updateCounters();
         }
@@ -95,7 +98,7 @@ public class CameraPhotosAdapter extends RecyclerView.Adapter<CameraPhotosAdapte
         void updateView(CameraPhoto cameraPhoto) {
             final Integer sampleSizeForSmallImages = 2;
 
-            getBitmapFromFile(getPrivateTempDirectory(), cameraPhoto.getLocalImageFilename(), sampleSizeForSmallImages,
+            getBitmapFromFile(getPrivateTempDirectory(mContext), cameraPhoto.getLocalImageFilename(), sampleSizeForSmallImages,
                     (bitmap) -> this.mCameraPhotosRecyclerViewBinding.cardShowTakenPictureViewGeneralCircularImageView.setImageBitmap(bitmap)
             );
 

--- a/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/utils/ImageDecoder.java
+++ b/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/utils/ImageDecoder.java
@@ -122,7 +122,7 @@ public class ImageDecoder {
         if (cardShowTakenImage.hasOnlyRemoteUrl()) {
             setBitmapFromInternet(imageView, cardShowTakenImage.getRemoteImageUrl());
         } else if (cardShowTakenImage.hasLocalImage()) {
-            getBitmapFromFile(getPrivateTempDirectory(), cardShowTakenImage.getLocalImageFilename(), sampleSize, imageView::setImageBitmap);
+            getBitmapFromFile(getPrivateTempDirectory(imageView.getContext()), cardShowTakenImage.getLocalImageFilename(), sampleSize, imageView::setImageBitmap);
         } else {
             getBitmapFromFile(cardShowTakenImage.getTempImagePathToShow(), sampleSize, imageView::setImageBitmap);
         }

--- a/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/utils/ImageGenerator.java
+++ b/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/utils/ImageGenerator.java
@@ -49,7 +49,7 @@ public class ImageGenerator {
             return;
         }
 
-        final File file = new File(getPrivateTempDirectory() + "/" + photoTaken.getName());
+        final File file = new File(getPrivateTempDirectory(mContext) + "/" + photoTaken.getName());
 
         final Integer sampleSizeForSmallImages = 2;
         getBitmapFromFile(photoTaken.getAbsolutePath(), sampleSizeForSmallImages,
@@ -59,7 +59,7 @@ public class ImageGenerator {
 
     public void generateCardShowTakenImageFromImageGallery(Uri data, Integer photoType,
                                                            CardShowTakenCompressedCallback cardShowTakenCompressedCallback) {
-        File photoTaken = new File(ImageViewFileUtil.getPrivateTempDirectory().toString());
+        File photoTaken = new File(ImageViewFileUtil.getPrivateTempDirectory(mContext).toString());
 
         try {
             photoTaken = ImageViewFileUtil.from(mContext, data);
@@ -76,14 +76,14 @@ public class ImageGenerator {
 
     private File createTempImageFileToShow(Bitmap bitmap, Integer typePhoto, Integer orientation) {
         String uuid = UUID.randomUUID().toString();
-        File file   = new File(ImageViewFileUtil.getPrivateTempDirectory().toString() + "/" + JPG_FILE_PREFIX + uuid + JPG_FILE_SUFFIX);
+        File file   = new File(ImageViewFileUtil.getPrivateTempDirectory(mContext).toString() + "/" + JPG_FILE_PREFIX + uuid + JPG_FILE_SUFFIX);
 
         final Integer desiredSize = 1400;
         Bitmap scaledBitmap       = ImageDecoder.scaleBitmap(bitmap, desiredSize);
         final int quality         = ImageDecoder.getImageQualityPercent(scaledBitmap);
 
         try {
-            FileOutputStream fileOutputStream  = new FileOutputStream(file);
+            FileOutputStream fileOutputStream  = mContext.openFileOutput(file.getName(), Context.MODE_PRIVATE);
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
             if (typePhoto.equals(fromCameraBack) || typePhoto.equals(fromCameraFront)) {

--- a/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/utils/ImageViewFileUtil.java
+++ b/cardshowviewtakenpicturesview/src/main/java/br/com/stant/libraries/cardshowviewtakenpicturesview/utils/ImageViewFileUtil.java
@@ -22,18 +22,9 @@ public class ImageViewFileUtil {
     public static final String JPG_FILE_PREFIX   = "IMG-";
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
     private static final int EOF                 = -1;
-    private static String tempPath               = "/<br.com.stant>/temp";
 
-    public static File getPrivateTempDirectory() {
-        File directory = new File(Environment.getExternalStorageDirectory(), tempPath);
-
-        if (directoryDoesNotExists(directory)) {
-            if (!createDirectory(directory)) {
-                Log.e(ImageGenerator.class.getCanonicalName(), "Directory not created");
-            }
-        }
-
-        return directory;
+    public static File getPrivateTempDirectory(Context context) {
+        return context.getFilesDir();
     }
 
     public static File getPublicAlbumDirectoryAtPictures(String albumName) {


### PR DESCRIPTION
- Use "open file output" method instead of "new FileOutputStream"
constructor to save the images at the temp folder
- "Open file folder" method creates a private folder to the app and
use it to save the temporary files

Signed-off-by: Eric Cerqueira Leao <ericcleao@gmail.com>